### PR TITLE
Remove version from multicast strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To try out the demo CLI chat application:
 
 Configure NFD to be multicast:
 
-    nfdc strategy set <sync-prefix> /localhost/nfd/strategy/multicast/
+    nfdc strategy set <sync-prefix> /localhost/nfd/strategy/multicast
 where `sync-prefix` is `/ndn/svs` for the example application.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ To try out the demo CLI chat application:
 
 Configure NFD to be multicast:
 
-    nfdc strategy set <sync-prefix> /localhost/nfd/strategy/multicast/%FD%03
-
+    nfdc strategy set <sync-prefix> /localhost/nfd/strategy/multicast/
 where `sync-prefix` is `/ndn/svs` for the example application.
 
 ## Contributing


### PR DESCRIPTION
The version of the multicast strategy has changed from 3 to 4. When using `/localhost/nfd/strategy/multicast/%FD%03`, NFD returns an error:
```
1626999042.388907 ERROR: [nfd.StrategyChoice] insert(/ndn/svs,/localhost/nfd/strategy/multicast/%FD%03) cannot create strategy: MulticastStrategy does not support version 3
Error 409 when setting strategy: Error instantiating strategy: MulticastStrategy does not support version 3
```