### PR TITLE
Change the fallback version suffix to `+git.{sha}`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,3 +26,4 @@ trim_trailing_whitespace = true
 [*.{yaml,yml}]
 indent_style = space
 indent_size = 2
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,20 @@
-# Emacs
+# Backup files
 *~
+*.bak
+*.orig
+*.rej
+
+# Waf build system
+/build/
+.waf-*-*/
+.waf3-*-*/
+.lock-waf*
+
+# Compiled python code
+__pycache__/
+*.py[cod]
+
+# Emacs
 \#*\#
 /.emacs.desktop
 /.emacs.desktop.lock
@@ -14,16 +29,6 @@
 .AppleDouble
 .LSOverride
 ._*
-
-# Waf build system
-/build/
-.waf-*-*/
-.waf3-*-*/
-.lock-waf*
-
-# Compiled python code
-__pycache__/
-*.py[cod]
 
 # Other
 /VERSION.info

--- a/.jenkins.d/00-deps.sh
+++ b/.jenkins.d/00-deps.sh
@@ -2,7 +2,8 @@
 set -eo pipefail
 
 APT_PKGS=(
-    build-essential
+    dpkg-dev
+    g++
     libboost-chrono-dev
     libboost-date-time-dev
     libboost-dev
@@ -16,7 +17,7 @@ APT_PKGS=(
     libsqlite3-dev
     libssl-dev
     pkg-config
-    python3-minimal
+    python3
 )
 FORMULAE=(boost openssl pkg-config)
 PIP_PKGS=()

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ndn-svs: State Vector Sync library for distributed realtime applications for NDN
 
-[![CI](https://github.com/named-data/ndn-svs/actions/workflows/ci.yml/badge.svg)](https://github.com/named-data/ndn-svs/actions/workflows/ci.yml)
 ![Language](https://img.shields.io/badge/C%2B%2B-17-blue)
+[![CI](https://github.com/named-data/ndn-svs/actions/workflows/ci.yml/badge.svg)](https://github.com/named-data/ndn-svs/actions/workflows/ci.yml)
 
 This library provides an implementation of the [State Vector Sync (SVS)](https://named-data.github.io/StateVectorSync/)
 protocol and the [Pub/Sub API](https://dl.acm.org/doi/abs/10.1145/3460417.3483376) for state

--- a/wscript
+++ b/wscript
@@ -173,43 +173,43 @@ def version(ctx):
     Context.g_module.VERSION_SPLIT = VERSION_BASE.split('.')
 
     # first, try to get a version string from git
-    gotVersionFromGit = False
+    version_from_git = ''
     try:
-        cmd = ['git', 'describe', '--always', '--match', f'{GIT_TAG_PREFIX}*']
-        out = subprocess.run(cmd, capture_output=True, check=True, text=True).stdout.strip()
-        if out:
-            gotVersionFromGit = True
-            if out.startswith(GIT_TAG_PREFIX):
-                Context.g_module.VERSION = out.lstrip(GIT_TAG_PREFIX)
+        cmd = ['git', 'describe', '--abbrev=8', '--always', '--match', f'{GIT_TAG_PREFIX}*']
+        version_from_git = subprocess.run(cmd, capture_output=True, check=True, text=True).stdout.strip()
+        if version_from_git:
+            if GIT_TAG_PREFIX and version_from_git.startswith(GIT_TAG_PREFIX):
+                Context.g_module.VERSION = version_from_git[len(GIT_TAG_PREFIX):]
+            elif not GIT_TAG_PREFIX and ('.' in version_from_git or '-' in version_from_git):
+                Context.g_module.VERSION = version_from_git
             else:
-                # no tags matched
-                Context.g_module.VERSION = f'{VERSION_BASE}-commit-{out}'
+                # no tags matched (or we are in a shallow clone)
+                Context.g_module.VERSION = f'{VERSION_BASE}+git.{version_from_git}'
     except (OSError, subprocess.SubprocessError):
         pass
 
-    versionFile = ctx.path.find_node('VERSION.info')
-    if not gotVersionFromGit and versionFile is not None:
+    # fallback to the VERSION.info file, if it exists and is not empty
+    version_from_file = ''
+    version_file = ctx.path.find_node('VERSION.info')
+    if version_file is not None:
         try:
-            Context.g_module.VERSION = versionFile.read()
-            return
-        except EnvironmentError:
-            pass
+            version_from_file = version_file.read().strip()
+        except OSError as e:
+            Logs.warn(f'{e.filename} exists but is not readable ({e.strerror})')
+    if version_from_file and not version_from_git:
+        Context.g_module.VERSION = version_from_file
+        return
 
-    # version was obtained from git, update VERSION file if necessary
-    if versionFile is not None:
-        try:
-            if versionFile.read() == Context.g_module.VERSION:
-                # already up-to-date
-                return
-        except EnvironmentError as e:
-            Logs.warn(f'{versionFile} exists but is not readable ({e.strerror})')
-    else:
-        versionFile = ctx.path.make_node('VERSION.info')
-
+    # update VERSION.info if necessary
+    if version_from_file == Context.g_module.VERSION:
+        # already up-to-date
+        return
+    if version_file is None:
+        version_file = ctx.path.make_node('VERSION.info')
     try:
-        versionFile.write(Context.g_module.VERSION)
-    except EnvironmentError as e:
-        Logs.warn(f'{versionFile} is not writable ({e.strerror})')
+        version_file.write(Context.g_module.VERSION)
+    except OSError as e:
+        Logs.warn(f'{e.filename} is not writable ({e.strerror})')
 
 def dist(ctx):
     ctx.algo = 'tar.xz'


### PR DESCRIPTION
Seems to be more commonly used than the current `-commit-{sha}`. But mainly this is just to keep the logic and versioning scheme consistent with other projects.

Also cleanup/simplify the version handling code and fix the list of dependencies in the CI scripts (`python3-minimal` is not enough).